### PR TITLE
Fix default get_translation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,3 +124,13 @@ PARLER_SHOW_EXCLUDED_LANGUAGE_TABS
 
 By default, the admin tabs are limited to the language codes found in :django:setting:`LANGUAGES`.
 If the models have other translations, they can be displayed by setting this value to ``True``.
+
+
+PARLER_DEFAULT_ACTIVATE
+----------------------------------
+
+::
+
+    PARLER_DEFAULT_ACTIVATE = True
+
+Setting, which allows to display translated texts in the default language even through ``translation.activate()`` is not called yet.

--- a/parler/utils/conf.py
+++ b/parler/utils/conf.py
@@ -8,8 +8,7 @@ import sys
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
-from django.utils.translation import get_language
-from parler.utils.i18n import is_supported_django_language, get_null_language_error
+from parler.utils.i18n import is_supported_django_language, get_null_language_error, get_language
 
 
 def add_default_language_settings(languages_list, var_name='PARLER_LANGUAGES', **extra_defaults):


### PR DESCRIPTION
Fix default `get_translation` to be used from patched method.
Add PARLER_DEFAULT_ACTIVATE to documentation